### PR TITLE
Fix for segv when no integral primitive screening is used. 

### DIFF
--- a/generator/ostei/OSTEIDeriv1_Writer.cpp
+++ b/generator/ostei/OSTEIDeriv1_Writer.cpp
@@ -713,6 +713,7 @@ void OSTEIDeriv1_Writer::Write_Full_(void) const
     os_ << indent3 << "for(i = istart; i < iend; ++i)\n";
     os_ << indent3 << "{\n";
     os_ << indent4 << "SIMINT_DBLTYPE bra_screen_max;  // only used if check_screen\n\n";
+    os_ << indent4 << "bra_screen_max = SIMINT_DBLSET1(0.);\n";
 
     os_ << indent4 << "if(check_screen)\n";
     os_ << indent4 << "{\n";

--- a/generator/ostei/OSTEI_Writer.cpp
+++ b/generator/ostei/OSTEI_Writer.cpp
@@ -499,6 +499,7 @@ void OSTEI_Writer::Write_Full_(void) const
     os_ << indent3 << "for(i = istart; i < iend; ++i)\n";
     os_ << indent3 << "{\n";
     os_ << indent4 << "SIMINT_DBLTYPE bra_screen_max;  // only used if check_screen\n\n";
+    os_ << indent4 << "bra_screen_max = SIMINT_DBLSET1(0.);\n";
 
     os_ << indent4 << "if(check_screen)\n";
     os_ << indent4 << "{\n";

--- a/generator/ostei/OSTEI_Writer.cpp
+++ b/generator/ostei/OSTEI_Writer.cpp
@@ -547,11 +547,12 @@ void OSTEI_Writer::Write_Full_(void) const
     WriteShellOffsets();
 
 
-    os_ << indent5 << "// Do we have to compute this vector (or has it been screened out)?\n";
-    os_ << indent5 << "// (not_screened != 0 means we have to do this vector)\n";
-    os_ << indent5 << "SIMINT_DBLTYPE prim_screen_res = SIMINT_MUL(bra_screen_max, SIMINT_DBLLOAD(Q.screen, j));\n";
+    os_ << indent5 << "SIMINT_DBLTYPE prim_screen_res = SIMINT_DBLSET1(0.);\n";
     os_ << indent5 << "if(check_screen)\n";
     os_ << indent5 << "{\n";
+    os_ << indent6 << "// Do we have to compute this vector (or has it been screened out)?\n";
+    os_ << indent6 << "// (not_screened != 0 means we have to do this vector)\n";
+    os_ << indent6 << "prim_screen_res = SIMINT_MUL(bra_screen_max, SIMINT_DBLLOAD(Q.screen, j));\n";
     os_ << indent6 << "const double vmax = vector_max(prim_screen_res);\n";
     os_ << indent6 << "if(vmax < screen_tol)\n";
     os_ << indent6 << "{\n";

--- a/skel/ostei_s_s_s_s.c
+++ b/skel/ostei_s_s_s_s.c
@@ -196,9 +196,10 @@ int ostei_s_s_s_s(struct simint_multi_shellpair const P,
 
                     // Do we have to compute this vector (or has it been screened out)?
                     // (not_screened != 0 means we have to do this vector)
-                    SIMINT_DBLTYPE prim_screen_res = SIMINT_MUL(bra_screen_max, SIMINT_DBLLOAD(Q.screen, j));
+                    SIMINT_DBLTYPE prim_screen_res = SIMINT_DBLSET1(0.);
                     if(check_screen)
                     {
+		      prim_screen_res = SIMINT_MUL(bra_screen_max, SIMINT_DBLLOAD(Q.screen, j));
                         const double vmax = vector_max(prim_screen_res);
                         if(vmax < screen_tol)
                         {

--- a/skel/ostei_s_s_s_s.c
+++ b/skel/ostei_s_s_s_s.c
@@ -199,6 +199,11 @@ int ostei_s_s_s_s(struct simint_multi_shellpair const P,
                     SIMINT_DBLTYPE prim_screen_res = SIMINT_DBLSET1(0.);
                     if(check_screen)
                     {
+		      if(jend -j < SIMINT_SIMD_LEN ){
+			//initialize remainders when vlen < SIMD_LEN			
+			for(int n = jend; n < j+SIMINT_SIMD_LEN; n++)
+			  Q.screen[n] = 0;
+		      }
 		      prim_screen_res = SIMINT_MUL(bra_screen_max, SIMINT_DBLLOAD(Q.screen, j));
                         const double vmax = vector_max(prim_screen_res);
                         if(vmax < screen_tol)

--- a/skel/ostei_s_s_s_s.c
+++ b/skel/ostei_s_s_s_s.c
@@ -201,8 +201,8 @@ int ostei_s_s_s_s(struct simint_multi_shellpair const P,
                     {
 		      if(jend -j < SIMINT_SIMD_LEN ){
 			//initialize remainders when vlen < SIMD_LEN			
-			for(int n = jend; n < j+SIMINT_SIMD_LEN; n++)
-			  Q.screen[n] = 0;
+			for(n = jend; n < j+SIMINT_SIMD_LEN; n++)
+			  Q.screen[n] = 0.;
 		      }
 		      prim_screen_res = SIMINT_MUL(bra_screen_max, SIMINT_DBLLOAD(Q.screen, j));
                         const double vmax = vector_max(prim_screen_res);

--- a/skel/ostei_s_s_s_s.c
+++ b/skel/ostei_s_s_s_s.c
@@ -125,6 +125,7 @@ int ostei_s_s_s_s(struct simint_multi_shellpair const P,
             for(i = istart; i < iend; ++i)
             {
                 SIMINT_DBLTYPE bra_screen_max;  // only used if check_screen
+		bra_screen_max = SIMINT_DBLSET1(0.);
 
                 if(check_screen)
                 {

--- a/skel/simint/shell/shell.c
+++ b/skel/simint/shell/shell.c
@@ -431,6 +431,7 @@ void simint_fill_multi_shellpair2(int npair, struct simint_shell const * AB,
     P->nshell12 = npair;
     P->nshell12_clip = npair; // by default, it's the same
     P->nprim = 0;
+    P->screen_max = 0.0;
 
     // zero out
     // This is not really needed, and can be expensive in
@@ -454,8 +455,6 @@ void simint_fill_multi_shellpair2(int npair, struct simint_shell const * AB,
             double m = simint_primscreen(A, B, P->screen + idx, screen_method);
             P->screen_max = (m > P->screen_max ? m : P->screen_max);
         }
-        else
-            P->screen_max = 0.0;
 
         // are these the same shells?
         const int same_shell = compare_shell(A, B);

--- a/skel/simint/shell/shell.c
+++ b/skel/simint/shell/shell.c
@@ -431,7 +431,7 @@ void simint_fill_multi_shellpair2(int npair, struct simint_shell const * AB,
     P->nshell12 = npair;
     P->nshell12_clip = npair; // by default, it's the same
     P->nprim = 0;
-    P->screen_max = 0.0;
+    P->screen_max = 1.e99;
 
     // zero out
     // This is not really needed, and can be expensive in


### PR DESCRIPTION
Should fix https://github.com/simint-chem/simint-generator/issues/7. I have tested it on a relatively large MP2 calculation.