### PR TITLE
Removing allocation of eri workspace in simint_primscreen_fastschwarz

### DIFF
--- a/skel/simint/shell/shell_screen.c
+++ b/skel/simint/shell/shell_screen.c
@@ -225,9 +225,6 @@ simint_primscreen_fastschwarz(struct simint_shell const * A,
                               double * restrict out)
 {
     // workspace
-    const size_t workmem = simint_ostei_workmem(0, SIMINT_OSTEI_MAXAM);
-    double * work = (double *)SIMINT_ALLOC(workmem);
-
     const int same_shell = compare_shell(A, B);
     double total_max = 0.0;
     int idx = 0;
@@ -266,6 +263,5 @@ simint_primscreen_fastschwarz(struct simint_shell const * A,
         }
     }
 
-    SIMINT_FREE(work);
     return total_max;
 }

--- a/skel/simint/shell/shell_screen.c
+++ b/skel/simint/shell/shell_screen.c
@@ -224,7 +224,6 @@ simint_primscreen_fastschwarz(struct simint_shell const * A,
                               struct simint_shell const * B,
                               double * restrict out)
 {
-    // workspace
     const int same_shell = compare_shell(A, B);
     double total_max = 0.0;
     int idx = 0;


### PR DESCRIPTION
This removes the allocation of workspace in routine simint_primscreen_fastschwarz in shell_screen.c.

As far as I can tell, the memory allocation is not necessary in this routine, since simint_compute_eri is not called, and the integrals are computed manually. (Right now it looks like the routine allocates the space at the beginning, and then deallocates it at the end without using it.)

Thanks! 