### PR TITLE
Change in ostei to free pointer, Issue #12

### DIFF
--- a/skel/ostei_s_s_s_s.c
+++ b/skel/ostei_s_s_s_s.c
@@ -79,7 +79,7 @@ int ostei_s_s_s_s(struct simint_multi_shellpair const P,
             if (j_vec > n_info_vector)
             {
                 n_info_vector = j_vec;
-                if (offset_info != NULL) free(offset_info);
+                free(offset_info);
                 offset_info  = (int*) malloc(sizeof(int) * (SIMINT_SIMD_LEN + 1 + TopAM_size) * n_info_vector);
             }
             // Calculate all the shell offsets in the j-loop

--- a/skel/ostei_s_s_s_s.c
+++ b/skel/ostei_s_s_s_s.c
@@ -79,7 +79,7 @@ int ostei_s_s_s_s(struct simint_multi_shellpair const P,
             if (j_vec > n_info_vector)
             {
                 n_info_vector = j_vec;
-                if (!offset_info) free(offset_info);
+                if (offset_info != NULL) free(offset_info);
                 offset_info  = (int*) malloc(sizeof(int) * (SIMINT_SIMD_LEN + 1 + TopAM_size) * n_info_vector);
             }
             // Calculate all the shell offsets in the j-loop


### PR DESCRIPTION
This is in reference to Issue #12 (more detail is there). Valgrind shows a memory leak for a test case, and this fix is meant to fix it. 

This changes the conditional in an if statement. Currently it checks if the pointer is NULL and frees it the pointer if it's NULL, which sounds strange:

```if (!offset_info) free(offset_info);```

The pointer itself should never be NULL since there's an assert statement around it earlier in the function.

This PR changes the code so that the pointer is freed if the pointer is nonNULL, not if the pointer is NULL. I think this is the correct fix, but let me know if I'm missing something. Thanks!